### PR TITLE
Add library prefix when syncing ACR debian registry

### DIFF
--- a/azure-pipelines/sync-docker-image.yml
+++ b/azure-pipelines/sync-docker-image.yml
@@ -41,10 +41,11 @@ jobs:
           images=$(find download -name versions-docker | xargs -i grep -v "==$" {} | awk -F== '{print$1}' | sed -e "s/amd64://" -e "s/arm64://" -e "s/armhf://" | sort -u )
           for i in $images $SYNC_DOCKER_IMAGE_EXTRA
           do
+            source = $i
             if [[ "$i" == debian* ]];then
-              i=library/$i
+              source=library/$i
             fi
-            az acr import -n PublicMirror --source docker.io/$i --image $i --force
+            az acr import -n PublicMirror --source docker.io/$source --image $i --force
           done
         displayName: push image to PublicMirror
         env:

--- a/azure-pipelines/sync-docker-image.yml
+++ b/azure-pipelines/sync-docker-image.yml
@@ -41,7 +41,7 @@ jobs:
           images=$(find download -name versions-docker | xargs -i grep -v "==$" {} | awk -F== '{print$1}' | sed -e "s/amd64://" -e "s/arm64://" -e "s/armhf://" | sort -u )
           for i in $images $SYNC_DOCKER_IMAGE_EXTRA
           do
-            source = $i
+            source=$i
             if [[ "$i" == debian* ]];then
               source=library/$i
             fi


### PR DESCRIPTION
Docker hub will redirect debian:* to library/debian:*
ACR will not redirect. So, we should sync library/debian to debian.
Otherwise, docker pull will fail for no registry found.