### PR TITLE
Add library prefix when syncing ACR ubuntu registry

### DIFF
--- a/azure-pipelines/sync-docker-image.yml
+++ b/azure-pipelines/sync-docker-image.yml
@@ -42,7 +42,7 @@ jobs:
           for i in $images $SYNC_DOCKER_IMAGE_EXTRA
           do
             source=$i
-            if [[ "$i" == debian* ]];then
+            if [[ "$i" == debian* ]] || [[ "$i" == ubuntu* ]];then
               source=library/$i
             fi
             az acr import -n PublicMirror --source docker.io/$source --image $i --force


### PR DESCRIPTION
ubuntu registry is also redirected by docker hub.
```
docker pull ubuntu:16.04
16.04: Pulling from library/ubuntu
```